### PR TITLE
Improve GPS waiting dialog: add vertical accuracy, remove timeout

### DIFF
--- a/app/src/main/java/com/taifun/checks/data/SensorDataRepository.kt
+++ b/app/src/main/java/com/taifun/checks/data/SensorDataRepository.kt
@@ -61,6 +61,13 @@ class SensorDataRepository(private val context: Context) {
     val accuracy: StateFlow<Float?> = _accuracy.asStateFlow()
 
     /**
+     * Precisión vertical del GPS en metros (disponible desde API 26)
+     * Indica la precisión de la medición de altitud
+     */
+    private val _verticalAccuracy = MutableStateFlow<Float?>(null)
+    val verticalAccuracy: StateFlow<Float?> = _verticalAccuracy.asStateFlow()
+
+    /**
      * Timestamp del último fix GPS (nanosegundos desde boot del sistema)
      * Se usa para calcular la antigüedad del fix y rechazar datos obsoletos
      */
@@ -316,6 +323,14 @@ class SensorDataRepository(private val context: Context) {
         // Accuracy in meters
         _accuracy.value = if (location.hasAccuracy()) {
             location.accuracy
+        } else {
+            null
+        }
+
+        // Vertical accuracy in meters (API 26+)
+        _verticalAccuracy.value = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O &&
+            location.hasVerticalAccuracy()) {
+            location.verticalAccuracyMeters
         } else {
             null
         }

--- a/app/src/main/java/com/taifun/checks/ui/components/GpsWaitingDialog.kt
+++ b/app/src/main/java/com/taifun/checks/ui/components/GpsWaitingDialog.kt
@@ -10,48 +10,41 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.taifun.checks.R
 import com.taifun.checks.data.SensorDataRepository
-import kotlinx.coroutines.delay
 import java.util.Locale
 
 /**
- * Required GPS accuracy for logging (in meters)
+ * Required GPS horizontal accuracy for logging (in meters)
  */
 const val GPS_REQUIRED_ACCURACY_M = 50f
 
 /**
- * Timeout for waiting for GPS fix (in milliseconds)
- */
-const val GPS_WAIT_TIMEOUT_MS = 30_000L
-
-/**
- * Dialog that waits for accurate GPS fix before allowing log save
+ * Dialog that waits for accurate GPS fix before allowing log save.
+ * Continues searching indefinitely until user takes action or GPS becomes accurate.
  *
- * @param accuracy Current GPS accuracy in meters (null if unknown)
+ * @param accuracy Current GPS horizontal accuracy in meters (null if unknown)
+ * @param verticalAccuracy Current GPS vertical accuracy in meters (null if unknown/API < 26)
  * @param altitude Current GPS altitude in meters (null if no fix)
  * @param hasValidAltitude Whether the altitude was actually measured by GPS (not just 0.0 default)
  * @param fixAgeMs Age of the last GPS fix in milliseconds (null if no fix)
+ * @param requiredVerticalAccuracy Required vertical accuracy in meters (from ICAO altitude diff setting)
  * @param onDismiss Called when user cancels
  * @param onSaveAnyway Called when user chooses to save with current (inaccurate) data
- * @param onKeepSearching Called when user wants to continue waiting for GPS
  * @param onGpsReady Called when GPS meets accuracy requirements
  */
 @Composable
 fun GpsWaitingDialog(
     accuracy: Float?,
+    verticalAccuracy: Float? = null,
     altitude: Double?,
     hasValidAltitude: Boolean = true,
     fixAgeMs: Long? = null,
+    requiredVerticalAccuracy: Float? = null,
     onDismiss: () -> Unit,
     onSaveAnyway: () -> Unit,
-    onKeepSearching: () -> Unit = {},
     onGpsReady: () -> Unit
 ) {
     // Check if GPS is good enough using enhanced validation
-    val isGpsGood = isGpsAccurateForLogging(accuracy, altitude, hasValidAltitude, fixAgeMs)
-
-    // Track if we've timed out - use key to allow reset
-    var timeoutKey by remember { mutableStateOf(0) }
-    var hasTimedOut by remember { mutableStateOf(false) }
+    val isGpsGood = isGpsAccurateForLogging(accuracy, verticalAccuracy, altitude, hasValidAltitude, fixAgeMs, requiredVerticalAccuracy)
 
     // Auto-close when GPS is good
     LaunchedEffect(isGpsGood) {
@@ -60,28 +53,21 @@ fun GpsWaitingDialog(
         }
     }
 
-    // Timeout after GPS_WAIT_TIMEOUT_MS - reset when timeoutKey changes
-    LaunchedEffect(timeoutKey) {
-        hasTimedOut = false
-        delay(GPS_WAIT_TIMEOUT_MS)
-        if (!isGpsGood) {
-            hasTimedOut = true
-        }
-    }
-
     // Calculate fix age for display
     val fixAgeSeconds = fixAgeMs?.let { it / 1000 }
     val isFixStale = fixAgeMs != null && fixAgeMs > SensorDataRepository.MAX_FIX_AGE_MS
 
+    // Check if vertical accuracy meets requirements
+    val isVerticalAccuracyGood = when {
+        requiredVerticalAccuracy == null -> true // No requirement
+        verticalAccuracy == null -> true // Not available, skip check
+        else -> verticalAccuracy <= requiredVerticalAccuracy
+    }
+
     AlertDialog(
         onDismissRequest = onDismiss,
         title = {
-            Text(
-                text = if (hasTimedOut)
-                    stringResource(R.string.gps_timeout_title)
-                else
-                    stringResource(R.string.gps_waiting_title)
-            )
+            Text(text = stringResource(R.string.gps_waiting_title))
         },
         text = {
             Column(
@@ -89,27 +75,18 @@ fun GpsWaitingDialog(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-                if (!hasTimedOut) {
-                    // Show progress indicator while waiting
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(48.dp)
-                    )
+                // Show progress indicator while waiting
+                CircularProgressIndicator(
+                    modifier = Modifier.size(48.dp)
+                )
 
-                    Text(
-                        text = stringResource(R.string.gps_waiting_message),
-                        textAlign = TextAlign.Center,
-                        style = MaterialTheme.typography.bodyMedium
-                    )
-                } else {
-                    // Show timeout message
-                    Text(
-                        text = stringResource(R.string.gps_timeout),
-                        textAlign = TextAlign.Center,
-                        style = MaterialTheme.typography.bodyMedium
-                    )
-                }
+                Text(
+                    text = stringResource(R.string.gps_waiting_message),
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.bodyMedium
+                )
 
-                // Show current accuracy
+                // Show current horizontal accuracy
                 Text(
                     text = if (accuracy != null) {
                         stringResource(R.string.gps_accuracy_current, String.format(Locale.US, "%.0f m", accuracy))
@@ -123,6 +100,23 @@ fun GpsWaitingDialog(
                         else -> MaterialTheme.colorScheme.error
                     }
                 )
+
+                // Show vertical accuracy if available and required
+                if (requiredVerticalAccuracy != null) {
+                    Text(
+                        text = if (verticalAccuracy != null) {
+                            stringResource(R.string.gps_vertical_accuracy_current, String.format(Locale.US, "%.0f m", verticalAccuracy))
+                        } else {
+                            stringResource(R.string.gps_vertical_accuracy_unknown)
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = when {
+                            verticalAccuracy != null && isVerticalAccuracyGood -> MaterialTheme.colorScheme.primary
+                            verticalAccuracy == null -> MaterialTheme.colorScheme.onSurfaceVariant
+                            else -> MaterialTheme.colorScheme.error
+                        }
+                    )
+                }
 
                 // Show altitude status (with validity check)
                 Text(
@@ -156,20 +150,9 @@ fun GpsWaitingDialog(
             }
         },
         confirmButton = {
-            if (hasTimedOut) {
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    // Keep searching button
-                    TextButton(onClick = {
-                        timeoutKey++ // Reset timeout
-                        onKeepSearching()
-                    }) {
-                        Text(stringResource(R.string.gps_keep_searching))
-                    }
-                    // Save anyway button
-                    TextButton(onClick = onSaveAnyway) {
-                        Text(stringResource(R.string.gps_save_anyway))
-                    }
-                }
+            // Always show save anyway button
+            TextButton(onClick = onSaveAnyway) {
+                Text(stringResource(R.string.gps_save_anyway))
             }
         },
         dismissButton = {
@@ -186,20 +169,25 @@ fun GpsWaitingDialog(
  * Requirements:
  * 1. Must have valid altitude (actually measured, not default 0.0)
  * 2. Fix must be recent (within MAX_FIX_AGE_MS, default 60 seconds)
- * 3. For internal GPS: accuracy <= 50m
+ * 3. For internal GPS: horizontal accuracy <= 50m
  * 4. For Bluetooth/NMEA GPS: if accuracy not available, skip accuracy check
+ * 5. If vertical accuracy is available and required, it must be <= requiredVerticalAccuracy
  *
- * @param accuracy GPS accuracy in meters (null for NMEA GPS without accuracy data)
+ * @param accuracy GPS horizontal accuracy in meters (null for NMEA GPS without accuracy data)
+ * @param verticalAccuracy GPS vertical accuracy in meters (null if unknown/API < 26)
  * @param altitude GPS altitude in meters
  * @param hasValidAltitude Whether altitude was actually measured (not default 0.0)
  * @param fixAgeMs Age of the GPS fix in milliseconds (null if unknown)
+ * @param requiredVerticalAccuracy Required vertical accuracy in meters (null to skip check)
  * @return true if GPS data is accurate enough for logging
  */
 fun isGpsAccurateForLogging(
     accuracy: Float?,
+    verticalAccuracy: Float? = null,
     altitude: Double?,
     hasValidAltitude: Boolean = true,
-    fixAgeMs: Long? = null
+    fixAgeMs: Long? = null,
+    requiredVerticalAccuracy: Float? = null
 ): Boolean {
     // Must have altitude in all cases
     if (altitude == null) return false
@@ -210,9 +198,14 @@ fun isGpsAccurateForLogging(
     // Fix must not be too old (if we have age info)
     if (fixAgeMs != null && fixAgeMs > SensorDataRepository.MAX_FIX_AGE_MS) return false
 
+    // Check horizontal accuracy if available
     // If accuracy is null (e.g., Bluetooth/NMEA GPS without accuracy data), skip accuracy check
-    if (accuracy == null) return true
+    if (accuracy != null && accuracy > GPS_REQUIRED_ACCURACY_M) return false
 
-    // Otherwise require accuracy <= 50m
-    return accuracy <= GPS_REQUIRED_ACCURACY_M
+    // Check vertical accuracy if both available and required
+    if (requiredVerticalAccuracy != null && verticalAccuracy != null) {
+        if (verticalAccuracy > requiredVerticalAccuracy) return false
+    }
+
+    return true
 }

--- a/app/src/main/java/com/taifun/checks/ui/screens/LogViewerScreen.kt
+++ b/app/src/main/java/com/taifun/checks/ui/screens/LogViewerScreen.kt
@@ -66,6 +66,10 @@ fun LogViewerScreen(
 
     // GPS accuracy for logging
     val gpsAccuracy by sensorRepo.accuracy.collectAsState()
+    val gpsVerticalAccuracy by sensorRepo.verticalAccuracy.collectAsState()
+    val altitude by sensorRepo.altitude.collectAsState()
+    val hasValidAltitude by sensorRepo.hasValidAltitude.collectAsState()
+    val icaoMaxAltitudeDiffM by settingsRepo.icaoMaxAltitudeDiffMFlow.collectAsState(initial = 50.0f)
     var showGpsWaitingDialog by remember { mutableStateOf(false) }
     var pendingLogText by remember { mutableStateOf<String?>(null) }
 
@@ -283,8 +287,14 @@ fun LogViewerScreen(
             onDismiss = { showCustomLogDialog = false },
             onSave = { logText ->
                 // logText already has default text if user left it empty
-                // Check if GPS is accurate enough
-                if (isGpsAccurateForLogging(gpsAccuracy, altitude)) {
+                // Check if GPS is accurate enough (including vertical accuracy)
+                if (isGpsAccurateForLogging(
+                    accuracy = gpsAccuracy,
+                    verticalAccuracy = gpsVerticalAccuracy,
+                    altitude = altitude,
+                    hasValidAltitude = hasValidAltitude,
+                    requiredVerticalAccuracy = icaoMaxAltitudeDiffM
+                )) {
                     // GPS is good, save directly
                     executeLogSave(logText)
                 } else {
@@ -303,12 +313,25 @@ fun LogViewerScreen(
         val language by settingsRepo.languageFlow.collectAsState(initial = "auto")
         val latitude by sensorRepo.latitude.collectAsState()
         val longitude by sensorRepo.longitude.collectAsState()
-        val altitude by sensorRepo.altitude.collectAsState()
+        val dialogAltitude by sensorRepo.altitude.collectAsState()
         val speedKmh by sensorRepo.speedKmh.collectAsState()
+
+        // Track fix age for GPS validation
+        var fixAgeMs by remember { mutableStateOf<Long?>(null) }
+        LaunchedEffect(Unit) {
+            while (true) {
+                fixAgeMs = sensorRepo.getFixAgeMs()
+                kotlinx.coroutines.delay(1000)
+            }
+        }
 
         GpsWaitingDialog(
             accuracy = gpsAccuracy,
-            altitude = altitude,
+            verticalAccuracy = gpsVerticalAccuracy,
+            altitude = dialogAltitude,
+            hasValidAltitude = hasValidAltitude,
+            fixAgeMs = fixAgeMs,
+            requiredVerticalAccuracy = icaoMaxAltitudeDiffM,
             onDismiss = {
                 showGpsWaitingDialog = false
                 pendingLogText = null
@@ -319,7 +342,7 @@ fun LogViewerScreen(
                         val success = logRepo.addLogEntry(
                             latitude = latitude,
                             longitude = longitude,
-                            altitudeMeters = altitude,
+                            altitudeMeters = dialogAltitude,
                             speedKmh = speedKmh,
                             logText = logText,
                             language = if (language == "en") "en" else "es"
@@ -342,7 +365,7 @@ fun LogViewerScreen(
                         val success = logRepo.addLogEntry(
                             latitude = latitude,
                             longitude = longitude,
-                            altitudeMeters = altitude,
+                            altitudeMeters = dialogAltitude,
                             speedKmh = speedKmh,
                             logText = logText,
                             language = if (language == "en") "en" else "es"

--- a/app/src/main/java/com/taifun/checks/ui/screens/StepScreen.kt
+++ b/app/src/main/java/com/taifun/checks/ui/screens/StepScreen.kt
@@ -407,6 +407,7 @@ fun StepScreen(
                     longitude = longitude,
                     speedKmh = speedKmh,
                     sensorRepo = sensorRepo,
+                    settingsRepo = settingsRepo,
                     logRepo = logRepo,
                     language = currentLanguage,
                     modifier = Modifier.padding(pad)
@@ -432,6 +433,7 @@ fun StepScreen(
                     longitude = longitude,
                     speedKmh = speedKmh,
                     sensorRepo = sensorRepo,
+                    settingsRepo = settingsRepo,
                     logRepo = logRepo,
                     language = currentLanguage,
                     haptic = haptic,
@@ -484,6 +486,7 @@ private fun StepByStepMode(
     longitude: Double?,
     speedKmh: Float?,
     sensorRepo: SensorDataRepository,
+    settingsRepo: SettingsRepository,
     logRepo: LogRepository,
     language: String,
     modifier: Modifier = Modifier
@@ -493,7 +496,9 @@ private fun StepByStepMode(
 
     // GPS accuracy for logging
     val gpsAccuracy by sensorRepo.accuracy.collectAsState()
+    val gpsVerticalAccuracy by sensorRepo.verticalAccuracy.collectAsState()
     val hasValidAltitude by sensorRepo.hasValidAltitude.collectAsState()
+    val icaoMaxAltitudeDiffM by settingsRepo.icaoMaxAltitudeDiffMFlow.collectAsState(initial = 50.0f)
     // Calculate fix age dynamically for UI updates
     var fixAgeMs by remember { mutableStateOf<Long?>(null) }
     LaunchedEffect(Unit) {
@@ -543,9 +548,11 @@ private fun StepByStepMode(
     if (showGpsWaitingDialog && pendingLogText != null) {
         GpsWaitingDialog(
             accuracy = gpsAccuracy,
+            verticalAccuracy = gpsVerticalAccuracy,
             altitude = altitude,
             hasValidAltitude = hasValidAltitude,
             fixAgeMs = fixAgeMs,
+            requiredVerticalAccuracy = icaoMaxAltitudeDiffM,
             onDismiss = {
                 showGpsWaitingDialog = false
                 pendingLogText = null
@@ -554,9 +561,6 @@ private fun StepByStepMode(
                 pendingLogText?.let { executeLogSave(it) }
                 showGpsWaitingDialog = false
                 pendingLogText = null
-            },
-            onKeepSearching = {
-                // Just reset timeout - dialog handles this internally
             },
             onGpsReady = {
                 pendingLogText?.let { executeLogSave(it) }
@@ -784,7 +788,7 @@ private fun StepByStepMode(
 
                                         // Check if GPS is accurate enough
                                         val logText = paso.log ?: ""
-                                        if (isGpsAccurateForLogging(gpsAccuracy, altitude, hasValidAltitude, fixAgeMs)) {
+                                        if (isGpsAccurateForLogging(gpsAccuracy, gpsVerticalAccuracy, altitude, hasValidAltitude, fixAgeMs, icaoMaxAltitudeDiffM)) {
                                             // GPS is good, save directly
                                             executeLogSave(logText)
                                         } else {
@@ -878,7 +882,7 @@ private fun StepByStepMode(
 
                                 // Check if GPS is accurate enough
                                 val logText = paso.log ?: ""
-                                if (isGpsAccurateForLogging(gpsAccuracy, altitude, hasValidAltitude, fixAgeMs)) {
+                                if (isGpsAccurateForLogging(gpsAccuracy, gpsVerticalAccuracy, altitude, hasValidAltitude, fixAgeMs, icaoMaxAltitudeDiffM)) {
                                     // GPS is good, save directly
                                     executeLogSave(logText)
                                 } else {
@@ -978,6 +982,7 @@ private fun FullListMode(
     longitude: Double?,
     speedKmh: Float?,
     sensorRepo: SensorDataRepository,
+    settingsRepo: SettingsRepository,
     logRepo: LogRepository,
     language: String,
     haptic: com.taifun.checks.ui.HapticFeedbackHelper,
@@ -1001,7 +1006,9 @@ private fun FullListMode(
 
     // GPS accuracy for logging
     val gpsAccuracy by sensorRepo.accuracy.collectAsState()
+    val gpsVerticalAccuracy by sensorRepo.verticalAccuracy.collectAsState()
     val hasValidAltitude by sensorRepo.hasValidAltitude.collectAsState()
+    val icaoMaxAltitudeDiffM by settingsRepo.icaoMaxAltitudeDiffMFlow.collectAsState(initial = 50.0f)
     // Calculate fix age dynamically for UI updates
     var fixAgeMs by remember { mutableStateOf<Long?>(null) }
     LaunchedEffect(Unit) {
@@ -1038,9 +1045,11 @@ private fun FullListMode(
     if (showGpsWaitingDialog && pendingLogText != null) {
         GpsWaitingDialog(
             accuracy = gpsAccuracy,
+            verticalAccuracy = gpsVerticalAccuracy,
             altitude = altitude,
             hasValidAltitude = hasValidAltitude,
             fixAgeMs = fixAgeMs,
+            requiredVerticalAccuracy = icaoMaxAltitudeDiffM,
             onDismiss = {
                 showGpsWaitingDialog = false
                 pendingLogText = null
@@ -1049,9 +1058,6 @@ private fun FullListMode(
                 pendingLogText?.let { executeLogSave(it) }
                 showGpsWaitingDialog = false
                 pendingLogText = null
-            },
-            onKeepSearching = {
-                // Just reset timeout - dialog handles this internally
             },
             onGpsReady = {
                 pendingLogText?.let { executeLogSave(it) }
@@ -1323,7 +1329,7 @@ private fun FullListMode(
 
                                     // Check if GPS is accurate enough
                                     val logText = p.log ?: ""
-                                    if (isGpsAccurateForLogging(gpsAccuracy, altitude, hasValidAltitude, fixAgeMs)) {
+                                    if (isGpsAccurateForLogging(gpsAccuracy, gpsVerticalAccuracy, altitude, hasValidAltitude, fixAgeMs, icaoMaxAltitudeDiffM)) {
                                         // GPS is good, save directly
                                         executeLogSave(logText)
                                     } else {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -307,6 +307,8 @@
     <string name="gps_waiting_message">Getting accurate position (≤50m)…</string>
     <string name="gps_accuracy_current">Current accuracy: %1$s</string>
     <string name="gps_accuracy_unknown">Current accuracy: unknown</string>
+    <string name="gps_vertical_accuracy_current">Vertical accuracy: %1$s</string>
+    <string name="gps_vertical_accuracy_unknown">Vertical accuracy: unknown</string>
     <string name="gps_altitude_waiting">Waiting for GPS altitude…</string>
     <string name="gps_altitude_ok">Altitude: %.0f m</string>
     <string name="gps_altitude_invalid">Altitude: not measured (invalid value)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -306,6 +306,8 @@
     <string name="gps_waiting_message">Obteniendo posición precisa (≤50m)…</string>
     <string name="gps_accuracy_current">Precisión actual: %1$s</string>
     <string name="gps_accuracy_unknown">Precisión actual: desconocida</string>
+    <string name="gps_vertical_accuracy_current">Precisión vertical: %1$s</string>
+    <string name="gps_vertical_accuracy_unknown">Precisión vertical: desconocida</string>
     <string name="gps_altitude_waiting">Esperando altitud GPS…</string>
     <string name="gps_altitude_ok">Altitud: %.0f m</string>
     <string name="gps_altitude_invalid">Altitud: no medida (valor inválido)</string>


### PR DESCRIPTION
- Add vertical accuracy tracking to SensorDataRepository (API 26+)
- Remove timeout from GPS waiting dialog - search continues indefinitely
- Always show "Cancel" and "Save anyway" buttons during GPS search
- Add vertical accuracy validation using ICAO altitude difference setting
- Display current horizontal accuracy, vertical accuracy, and altitude
- Vertical accuracy only shown/required when requiredVerticalAccuracy is set
- Update string resources for vertical accuracy (Spanish/English)