### PR TITLE
Fix GPS precision validation for Bluetooth NMEA devices

### DIFF
--- a/app/src/main/java/com/taifun/checks/data/SensorDataRepository.kt
+++ b/app/src/main/java/com/taifun/checks/data/SensorDataRepository.kt
@@ -126,6 +126,17 @@ class SensorDataRepository(private val context: Context) {
             _longitude.value = longitude
             _altitude.value = altitude
             _speedKmh.value = speedKmh
+
+            // Update validity flag: altitude is valid if it's non-null
+            // NMEA GPS provides altitude from GGA sentences when it has a valid fix
+            // If the GPS has no altitude data, the NMEA field is empty (parsed as null)
+            _hasValidAltitude.value = altitude != null
+
+            // Update fix timestamp when we receive valid GPS data (lat/lon present)
+            // This allows getFixAgeMs() to work correctly for NMEA GPS
+            if (latitude != null && longitude != null) {
+                _lastFixElapsedRealtimeNanos.value = SystemClock.elapsedRealtimeNanos()
+            }
         }
     }
 


### PR DESCRIPTION
The GPS waiting dialog was not working with Bluetooth NMEA GPS because updateExternalGpsData() was not updating the required validation fields.

Changes:
- Update hasValidAltitude flag when receiving valid altitude from NMEA
- Update lastFixElapsedRealtimeNanos timestamp when receiving GPS data
- This allows getFixAgeMs() and isGpsAccurateForLogging() to work correctly

The validation now properly detects:
- Valid altitude measurements (not just default values)
- Fix age to reject stale data (>60 seconds)
- GPS accuracy when available from NMEA

Fixes the issue where the dialog would wait indefinitely for precision when using Bluetooth GPS devices.